### PR TITLE
🐛 Poweroff after copy from iso

### DIFF
--- a/k3os.pkr.hcl
+++ b/k3os.pkr.hcl
@@ -30,7 +30,7 @@ variable "git_sha" {
 
 locals {
   boot_command_pre  = ["<wait>", "<tab>", "<down>", "<wait>", "e", "<down>", "<down>", "<down>", "<down>", "<down>", "<down>", "<end>"]
-  boot_command_args = [" ", "k3os.install.device=/dev/sda", " ", "k3os.mode=install", " ", "k3os.install.silent=true", " ", "k3os.install.debug=true", " ", "k3os.install.power_off=false"]
+  boot_command_args = [" ", "k3os.install.device=/dev/sda", " ", "k3os.mode=install", " ", "k3os.install.silent=true", " ", "k3os.install.debug=true", " ", "k3os.install.power_off=true"]
   boot_command_post = ["<F10>"]
 }
 


### PR DESCRIPTION
Ensures the VM template doesn't contain SSH host keys etc